### PR TITLE
Added `Rhetos:Jobs:Hangfire:AutomaticRetryAttempts` option to control…

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Rhetos.Jobs Release notes
 
+## 1.2.0 (2023-05-25)
+
+* Added `Rhetos:Jobs:Hangfire:AutomaticRetryAttempts` option to control how many times Hangfire will try to execute method if error occurs (default value is 10). Also, you can control the time between each unsuccessfull execution with `Rhetos:Jobs:Hangfire:DelaysInSeconds` option (if empty, Hangfire default exponential delay time will apply). 
+
 ## 1.1.0 (2022-02-14)
 
 * Recurring jobs supported, specified by a [CRON expression](https://en.wikipedia.org/wiki/Cron#CRON_expression).

--- a/Readme.md
+++ b/Readme.md
@@ -151,7 +151,9 @@ Configuration of the plugin is done in `rhetos-app.settings.json`, like in the f
         "HeartbeatInterval": 30, //Value is in seconds. Default value is 30. For usage of the option see Hangfire documentation.
         "ServerTimeout": 300, //Value is in seconds. Default value is 300. For usage of the option see Hangfire documentation.
         "ServerCheckInterval": 300, //Value is in seconds. Default value is 300. For usage of the option see Hangfire documentation.
-        "CancellationCheckInterval": 5 //Value is in seconds. Default value is 5. For usage of the option see Hangfire documentation.
+        "CancellationCheckInterval": 5, //Value is in seconds. Default value is 5. For usage of the option see Hangfire documentation.
+        "AutomaticRetryAttempts": 5 //Default value is 10. Added to GlobalJobFilters.Filters via AutomaticRetryAttribute. For usage of the AutomaticRetryAttribute see Hangfire documentation.
+        "DelaysInSeconds": "1, 60, 3600" //Delays in seconds for retry jobs (i.e. "1, 60, 3600"). Default value is Hangfire default. For usage of the default algorithm see Hangfire documentation.
       }
     }
   }

--- a/src/Rhetos.Jobs.Hangfire/RhetosHangfireInitialization.cs
+++ b/src/Rhetos.Jobs.Hangfire/RhetosHangfireInitialization.cs
@@ -21,6 +21,7 @@ using Hangfire;
 using Hangfire.SqlServer;
 using Rhetos.Utilities;
 using System;
+using System.Linq;
 
 namespace Rhetos.Jobs.Hangfire
 {
@@ -68,8 +69,17 @@ namespace Rhetos.Jobs.Hangfire
 								DisableGlobalLocks = _options.DisableGlobalLocks
 							});
 
+						var automaticRetryAttribute = new AutomaticRetryAttribute { Attempts = _options.AutomaticRetryAttempts };
+						if (!string.IsNullOrEmpty(_options.DelaysInSeconds))
+							automaticRetryAttribute.DelaysInSeconds = ParseDelaysInSeconds();
+
+						GlobalJobFilters.Filters.Add(automaticRetryAttribute);
+
 						_initialized = true;
 					}
 		}
+
+		private int[] ParseDelaysInSeconds() => 
+			_options.DelaysInSeconds.Split(',').Select(x => int.Parse(x)).ToArray();
 	}
 }

--- a/src/Rhetos.Jobs.Hangfire/RhetosJobHangfireOptions.cs
+++ b/src/Rhetos.Jobs.Hangfire/RhetosJobHangfireOptions.cs
@@ -99,5 +99,13 @@ namespace Rhetos.Jobs.Hangfire
 		/// Array of queue names which will be processed by this instance of Hangfire server. Default is '["default"]'.
 		/// </summary>
 		public string[] Queues { get; set; } = {"default"};
+		/// <summary>
+		/// Default value is 10. Added to GlobalJobFilters.Filters via AutomaticRetryAttribute. For usage of the AutomaticRetryAttribute see Hangfire documentation.
+		/// </summary>
+		public int AutomaticRetryAttempts { get; set; } = 10;
+		/// <summary>
+		/// Delays in seconds for retry jobs (i.e. "1, 60, 3600"). Default value is Hangfire default. For usage of the default algorithm see Hangfire documentation.
+		/// </summary>
+		public string DelaysInSeconds { get; set; }
 	}
 }


### PR DESCRIPTION
… how many times Hangfire will try to execute method if error occurs (default value is 10).

Also, you can control the time between each unsuccessfull execution with `Rhetos:Jobs:Hangfire:DelaysInSeconds` option (if empty, Hangfire default exponential delay time will apply)